### PR TITLE
Test against Django 3.1

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 isolated_build = true
-envlist = clean,py{36,37,38}-django{22,30},report
+envlist = clean,py{36,37,38}-django{22,30,31},report
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 whitelist_externals =
   poetry
   bash


### PR DESCRIPTION
Django 3.1 introduced substantial internal changes. This ensures all Django libraries
are tested against 3.1.

@tomage I have verified this change locally. There were some breaking changes in django-pghistory based on internal Django changes in 3.1, so I thought it would be good if all libraries were eventually forced to test against 3.1